### PR TITLE
fix ci: remove redundant apt-get install step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,6 @@ jobs:
       with:
         python-version: '3.14.4'
     
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-glx libglib2.0-0
-    
     - name: Install dependencies
       run: |
         cd src/tests


### PR DESCRIPTION
The 'Install system dependencies' step (libgl1-mesa-glx, libglib2.0-0) is redundant since 'Install Playwright browsers' already runs 'playwright install --with-deps chromium' which installs all required system packages. The apt-get step has been failing consistently on the self-hosted runner since mid-April.

Fixes goatheckler/human-detector#88