### PR TITLE
fix ci: add pytest junit artifact for debugging failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,15 @@ jobs:
     - name: Run tests
       run: |
         cd src/tests
-        pytest -v
+        pytest -v --tb=short --junit-xml=test-results.xml
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: src/tests/test-results.xml
+        retention-days: 3
     
     - name: Print logs on failure
       if: failure()


### PR DESCRIPTION
Add pytest junit-xml output so that when tests fail, we get an artifact with the actual failure details instead of losing them to log-only output.

Fixes goatheckler/human-detector#88