### PR TITLE
fix ci: upload pytest junit artifact + remove redundant backend pip install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     
     - name: Start backend API
       run: |
-        pip install -r src/backend/requirements.txt
         nohup uvicorn src.backend.api.main:app --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
         echo $! > backend.pid
         sleep 5
@@ -55,7 +54,15 @@ jobs:
     - name: Run tests
       run: |
         export PYTHONPATH="$GITHUB_WORKSPACE"
-        pytest -v --tb=short
+        pytest -v --tb=short --junit-xml=test-results.xml
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: test-results.xml
+        retention-days: 1
     
     - name: Print logs on failure
       if: failure()


### PR DESCRIPTION
Two fixes:

1. **Upload junit artifact**: Previous runs had no artifacts, making it impossible to see actual test failures. This adds `--junit-xml=test-results.xml` and uploads the artifact so we can debug the next failure.

2. **Remove redundant backend install**: The 'Start backend API' step was re-running `pip install -r src/backend/requirements.txt` which would undo the pytest filtering from the 'Install dependencies' step. Backend deps are already installed there — no need to reinstall.

Fixes goatheckler/human-detector#88