### PR TITLE
fix ui tests: wait for Max Confidence metric instead of Detection Result header

### DIFF
--- a/src/tests/ui/test_ui_upload.py
+++ b/src/tests/ui/test_ui_upload.py
@@ -39,8 +39,9 @@ def upload_file_and_detect(page: Page, file_path: Path):
     except:
         pass  # No error, continue
     
-    # Wait for results with extended timeout
-    page.wait_for_selector("text=Detection Result", timeout=30000)
+    # Wait for the specific result element (st.info/st.success renders after subheader)
+    # Use the metric text as a reliable proxy for "results have rendered"
+    expect(page.locator("text=Max Confidence")).to_be_visible(timeout=30000)
 
 def test_ui_loads(page: Page):
     wait_for_streamlit(page)


### PR DESCRIPTION
Race condition fix: `upload_file_and_detect` was waiting for `'text=Detection Result'` (the subheader) before checking the result, but `st.info('❌ No Human Detected')` renders after the subheader on slower CI runners.

Fix: wait for `'text=Max Confidence'` instead — a metric that's guaranteed to appear only after the result is fully rendered. This also makes the wait more robust since it won't false-positive on a just-rendered section header missing its content.

Fixes goatheckler/human-detector#88