### PR TITLE
fix: use Python 3.14.5 instead of 3.14.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.14.6'
+        python-version: '3.14.5'
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Problem

The `Tests` workflow failed on PR #124 (renovate/all-dependencies) because `actions/setup-python@v5` does not yet have Python 3.14.6 cached for Ubuntu 24.04 x64 runners.



## Fix

Downgrade to Python 3.14.5, which is confirmed available for `linux-24.04-x64` in the `actions/python-versions` manifest.

## Testing

CI will run against this PR to confirm the fix.